### PR TITLE
removed label for gexpandgroup control checkbox, replaced with text attribute of disclose_icon ttkcheckbutton, this avoids bad looking space between checkbox and text and selection highlight glitche

### DIFF
--- a/R/gexpandgroup.R
+++ b/R/gexpandgroup.R
@@ -22,14 +22,13 @@ GExpandGroup <- setRefClass("GExpandGroup",
                               label="ANY",
                               inner_frame="ANY"
                               ),
-                            methods=list(
-                              initialize=function(toolkit=NULL, text="", markup=FALSE, horizontal=TRUE, handler, action=NULL, container=NULL, ...) {
+                            methods = list(
+                              initialize = function(toolkit=NULL, text="", markup=FALSE, horizontal=TRUE, handler, action=NULL, container=NULL, ...) {
 
                                 block <<- ttkframe(container$get_widget())
                                 inner_frame <<- ttkframe(block)
                                 t_var <<- tclVar(1)
                                 disclose_icon <<- ttkcheckbutton(inner_frame,  variable=t_var)
-                                label <<- ttklabel(inner_frame)
                                 widget <<- ttkframe(block)
 
                                 do_layout()
@@ -46,10 +45,9 @@ GExpandGroup <- setRefClass("GExpandGroup",
                                 
                                 callSuper(toolkit, horizontal=horizontal, ...)
                               },
-                              do_layout=function() {
+                              do_layout = function() {
                                 tkpack(inner_frame, expand=FALSE, fill="x", side="top")
                                 tkpack(disclose_icon, expand=FALSE, fill="none", anchor="w", side="left")
-                                tkpack(label, expand=TRUE, fill="x", anchor="w", side="left", padx=2)
 
                                 
                                 tkpack(widget, expand=TRUE, fill="both", anchor="nw")
@@ -59,21 +57,21 @@ GExpandGroup <- setRefClass("GExpandGroup",
                                         tcl("event", "generate", widget, change_signal)
                                 })
                               },
-                              get_names=function(...) {
-                                as.character(tkcget(label, "-text"))
+                              get_names = function(...) {
+                                as.character(tkcget(disclose_icon, "-text"))
                               },
-                              set_names=function(value, ...) {
-                                tkconfigure(label, text=paste(value, collapse=" "))
+                              set_names = function(value, ...) {
+                                tkconfigure(disclose_icon, text=paste(value, collapse=" "))
                               },
                               get_visible = function() {
                                 tclvalue(t_var) == "1"
                               },
-                              show_container=function() {
+                              show_container = function() {
                                 tkpack("propagate", block, TRUE)
 #                                tkpack("propagate", widget, FALSE)
                                 tkpack(widget, expand=TRUE, fill="both")
                               },
-                              hide_container=function() {
+                              hide_container = function() {
                                 width <- as.numeric(tkwinfo("width", widget))
 #                                tkpack("propagate", block, FALSE)
                                 ## configure height but not width!!!
@@ -86,14 +84,14 @@ GExpandGroup <- setRefClass("GExpandGroup",
                                 if(value) show_container() else hide_container()
                                 tcl("event", "generate", widget, change_signal)
                               },
-                              set_enabled=function(value) {
-                                sapply(list(disclose_icon, label), function(i) {
+                              set_enabled = function(value) {
+                                sapply(list(disclose_icon), function(i) {
                                   tcl(i, "state", ifelse(value, "!disabled", "disabled"))
                                 })
                                 callSuper(value)
                               },
-                              set_font=function(value) {
-                                set_font_ttk(value, label)
+                              set_font = function(value) {
+                                set_font_ttk(value, disclose_icon)
                               }
                               ))
                             


### PR DESCRIPTION
Using label we had this behaviour:

![withlabel1](https://cloud.githubusercontent.com/assets/405331/20238404/286d47d8-a8eb-11e6-9a5b-97cdd19d1aed.png)
![withlabel2](https://cloud.githubusercontent.com/assets/405331/20238405/288fd708-a8eb-11e6-9248-ab418322c6c9.png)
![withlabel3](https://cloud.githubusercontent.com/assets/405331/20238406/288fce02-a8eb-11e6-8495-8aa39f42d71a.png)

switching to text property of ttkcheckbutton the behaviour now is:

![withtext1](https://cloud.githubusercontent.com/assets/405331/20238414/62cd53f0-a8eb-11e6-9ca5-ef4aa50746c0.png)
![withtext2](https://cloud.githubusercontent.com/assets/405331/20238416/62f46fe4-a8eb-11e6-8f97-0a3b779a5c48.png)
![withtext3](https://cloud.githubusercontent.com/assets/405331/20238415/62ef9924-a8eb-11e6-8902-0e8d678c5893.png)
